### PR TITLE
Added WordPress Uninstall Check

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -1,11 +1,10 @@
 <?php
+//if uninstall not called from WordPress exit
+if ( !defined( 'WP_UNINSTALL_PLUGIN' ) ) 
+    exit();
+  
 global $wpdb;
-
 $table_name = $wpdb->prefix . "erictable";
-
 $sql = "DROP TABLE IF EXISTS ".$table_name;
-
 $results = $wpdb->query( $sql );
-
-
 ?>


### PR DESCRIPTION
Forgot to mention this security step: Added check to ensure to uninstall only when WordPress is calling the file.

For the uninstall.php file, you should always check to see if WP_UNINSTALL_PLUGIN is defined. WordPress creates this constant when starting the uninstall process before calling your file.  This way, only if WordPress calls the file will it uninstall the plugin. So, if someone went to plugins/final-quote-plugin/uninstall.php, they wouldn't uninstall the files.
